### PR TITLE
Add table with most important Nix operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ important is missing.
 - [Overview](#overview)
 - [Language constructs](#language-constructs)
     - [Primitives / literals](#primitives--literals)
+    - [Operators](#operators)
     - [Variable bindings](#variable-bindings)
     - [Functions](#functions)
         - [Multiple arguments (currying)](#multiple-arguments-currying)
@@ -103,6 +104,28 @@ second line
 # recursive attribute sets (fields can reference each other)
 rec { a = 15; b = a * 2; }
 ```
+
+## Operators
+
+Nix has several operators, most of which are unsurprising:
+
+| Syntax               | Description                                                                 |
+|----------------------|-----------------------------------------------------------------------------|
+| `+`, `-`, `*`, `/`   | Numerical operations                                                        |
+| `+`                  | String concatenation                                                        |
+| `++`                 | List concatenation                                                          |
+| `==`                 | Equality                                                                    |
+| `>`, `>=`, `<`, `<=` | Ordering comparators                                                        |
+| `&&`                 | Logical `AND`                                                               |
+| `\|\|`               | Logical `OR`                                                                |
+| `e1 -> e2`           | Logical implication (i.e. `!e1 \|\| e2`)                                    |
+| `!`                  | Boolean negation                                                            |
+| `set.attr`           | Access attribute `attr` in attribute set `set`                              |
+| `set ? attribute`    | Test whether attribute set contains an attribute                            |
+| `left // right`      | Merge `left` & `right` attribute sets, with the right set taking precedence |
+
+Make sure to understand the `//`-operator, as it is used quite a lot and is
+probably the least familiar one.
 
 ## Variable bindings
 


### PR DESCRIPTION
These operators were sourced from the existing [Nix manual](https://nixos.org/nix/manual/#sec-language-operators) and [this gist](https://gist.github.com/joepie91/c3c047f3406aea9ec65eebce2ffd449d) by @joepie91