### PR TITLE
Fix rendering of pipes in code blocks across dialects

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Nix has several operators, most of which are unsurprising:
 | `==`                 | Equality                                                                    |
 | `>`, `>=`, `<`, `<=` | Ordering comparators                                                        |
 | `&&`                 | Logical `AND`                                                               |
-| `\|\|`               | Logical `OR`                                                                |
-| `e1 -> e2`           | Logical implication (i.e. `!e1 \|\| e2`)                                    |
+| <code>&vert;&vert;</code> | Logical `OR`                                                           |
+| `e1 -> e2`           | Logical implication (i.e. <code>!e1 &vert;&vert; e2</code>)                 |
 | `!`                  | Boolean negation                                                            |
 | `set.attr`           | Access attribute `attr` in attribute set `set`                              |
 | `set ? attribute`    | Test whether attribute set contains an attribute                            |


### PR DESCRIPTION
Pipes inside of code blocks inside of tables seem to pose a challenge
for some Markdown renderers. Not a problem for Github's but this page
is occasionally embedded in other documentation (such as nixery.dev).

Relates to https://github.com/google/nixery/issues/44