### PR TITLE
Update documentation to reflect change in convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ but have the modification above be reflected in the imported package set:
 
 ```nix
 let
-  overlay = (self: super: {
+  overlay = (final: prev: {
     someProgram = super.someProgram.overrideAttrs(old: {
       configureFlags = old.configureFlags or [] ++ ["--mimic-threaten-tag"];
     });
@@ -577,9 +577,9 @@ let
 in import <nixpkgs> { overlays = [ overlay ]; }
 ```
 
-The overlay function receives two arguments, `self` and `super`. `self` is
+The overlay function receives two arguments, `final` and `prev`. `final` is
 the [fixed point][fp] of the overlay's evaluation, i.e. the package set
-*including* the new packages and `super` is the "original" package set.
+*including* the new packages and `prev` is the "original" package set.
 
 See the Nix manual sections [on overrides][] and [on overlays][] for more
 details.

--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ the [fixed point][fp] of the overlay's evaluation, i.e. the package set
 *including* the new packages and `prev` is the "original" package set.
 
 See the Nix manual sections [on overrides][] and [on overlays][] for more
-details.
+details. (Note that the convention has moved away from using `self` in favor of `final` and `prev` instead of `super` but the documentation hasn't been update to reflect this.)
 
 [currying]: https://en.wikipedia.org/wiki/Currying
 [builtins]: https://nixos.org/nix/manual/#ssec-builtins


### PR DESCRIPTION
The convention has changed to use `final` instead of `self` and `prev` instead of `super`.
This new convention is much easier to understand especially for users that are new to Nix and Nixpkgs.
This change is notable in the Nixpkgs project code.
I added a note mentioning that the official documentation hasn't been update with this information.
The documentation is currently undergoing an overhaul and that is why I believe this hasn't been reflected in
the nixpkgs documentation as of yet.